### PR TITLE
Initial Logger Implementation

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -4,7 +4,7 @@ INCLUDE_PATH=include
 BIN_PATH=bin
 LOG_PATH=log
 APPLICATION_NAME=quicksocket
-FILES=quicksocket.C http_request.C http_response.C tcp_listener.C websocket_frame.C
+FILES=log.cpp quicksocket.cpp http_request.cpp http_response.cpp tcp_listener.cpp websocket_frame.cpp
 SOURCES = $(FILES:%.cpp=$(SOURCE_PATH)/%.cpp)
 OBJ=$(FILES:%.C=$(BUILD_PATH)/%.o)
 

--- a/server/include/log.hpp
+++ b/server/include/log.hpp
@@ -1,0 +1,18 @@
+#ifndef SUEDE_LOG_H_
+#define SUEDE_LOG_H_
+
+#include <stdio.h>
+
+class Log
+{
+	static FILE * LogFile;
+	static bool LogToConsole;
+	
+	public:
+	static void Initialize(void);
+	static void Initialize(int);
+	static void LogEvent(const char *);
+	static void Finalize(void);
+};
+
+#endif // SUEDE_LOG_H_

--- a/server/src/log.cpp
+++ b/server/src/log.cpp
@@ -1,0 +1,76 @@
+#include <iostream>
+#include <stdio.h>
+#include <ctime>
+#include <mutex>
+#include <log.hpp>
+
+FILE * Log::LogFile = NULL;
+bool Log::LogToConsole = false;
+
+std::mutex AccessLog;
+std::mutex Logging;
+
+void Log::Initialize(void)
+{
+	// Default initialization to type 0 (log to file)
+	
+	Logging.lock();
+	LogFile = fopen("LOGFILE", "a");
+	LogToConsole = false;
+}
+
+void Log::Initialize(int type)
+{
+	// Type 0: log to file || Type 1: log to console || Type 2: log to file and console
+	
+	Logging.lock();
+	switch(type) {
+	case 0:
+		LogFile = fopen("LOGFILE", "a");
+		LogToConsole = false;
+		fprintf(LogFile, "Logging Initialized (File Only)\n");
+		break;
+	case 1:
+		LogToConsole = true;
+		std::cerr << "Logging Initialized (Console Only)" << std::endl;
+		break;
+	case 2:
+		LogFile = fopen("LOGFILE", "a");	
+		LogToConsole = true;
+		std::cerr << "Logging Initialized (Console and File)" << std::endl;
+		fprintf(LogFile, "Logging Initialized (Console and File)\n");
+		break;
+	}
+}
+
+void Log::LogEvent(const char * Msg)
+{
+	AccessLog.lock();
+	
+	if (LogToConsole)
+	{
+		std::cerr << Msg << std::endl;
+	}
+	
+	if (LogFile != NULL)
+	{
+		fprintf(LogFile,"%s\n", Msg);
+	}
+	AccessLog.unlock();
+}
+
+void Log::Finalize(void)
+{
+	if (LogFile != NULL)
+	{
+		fprintf(LogFile, "\n");
+		fclose(LogFile);
+	}
+	
+	if (LogToConsole)
+	{
+		LogToConsole = false;
+	}
+	
+	Logging.unlock();
+}

--- a/server/test/logtest.cpp
+++ b/server/test/logtest.cpp
@@ -1,0 +1,28 @@
+#include <log.hpp>
+
+int main()
+{
+	//Log::LogEvent("bad message"); // This should fail (uninitialized logger)
+	
+	Log::Initialize(0);
+	Log::LogEvent("[1]Should see only in logfile");
+	Log::LogEvent("[2]Should also see only in logfile");
+	
+	//Log::Initialize(); // This should fail (pre-existing logger)
+	
+	Log::Finalize();
+	
+	//Log::Finalize(); // This should fail (uninitialized logger)
+	
+	// Print only to console
+	Log::Initialize(1);
+	Log::LogEvent("[3]Should only see in console");
+	Log::Finalize;
+	
+	// Print to both
+	Log::Initialize(2);
+	Log::LogEvent("[4]Should see in both console and logfile");
+	Log::Finalize;
+	
+	return 0;
+}


### PR DESCRIPTION
Barebones logging implementation. Successfully logs to file and/or stderr.

Functions:
- Log::Initialize(int [optional]): initializes logger
  -- Optional arg (int): type (0 - log to file; 1 - log to stderr; 2 - log to both)
  -- If not specified defaults to 0 (log file only)
- Log::LogEvent(char *): logs an event
- Log::Finalize(): runs cleanup and closes current logfile

Note: doesn't currently have timestamps and doesn't differentiate between message types (error vs warning vs debug) but it does work. Should be functional in the short term for testing purposes until I can finish building in functionality. Did include a test for the logger under ./server/test/logtest.cpp plan is to convert to google testing framework assuming we have decided that's the way to go.
